### PR TITLE
Add Sagar Gupta's portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@
 | Pratik Kumar | [pr2tik1/pr2tik1.github.io](https://github.com/pr2tik1/pr2tik1.github.io) | [pr2tik1.github.io](https://pr2tik1.github.io) |
 | Jayant Goel | [JayantGoel001/JayantGoel001.github.io](https://github.com/JayantGoel001/JayantGoel001.github.io) | [JayantGoel001.github.io](https://JayantGoel001.github.io/) |
 
+| Sagar Gupta | [Sagargupta16/portfolio-react](https://github.com/Sagargupta16/portfolio-react) | [sagargupta.online/portfolio-react](https://sagargupta.online/portfolio-react/) |
+
 ## Tools
 
 - [Information to build your portfolio](https://github.com/simplonco/portfolio) - *Simplonco*


### PR DESCRIPTION
Added my React portfolio hosted on GitHub Pages to the Templates table.

- **Name:** Sagar Gupta
- **Repository:** [Sagargupta16/portfolio-react](https://github.com/Sagargupta16/portfolio-react)
- **Live Demo:** [sagargupta.online/portfolio-react](https://sagargupta.online/portfolio-react/)
- **Tech:** React, Vite, Tailwind CSS, GitHub Pages

(Re-submitted with a clean diff -- previous PR #8 had line-ending artifacts from base64 encoding. This one only adds 1 table row.)