### PR TITLE
Add Portfolio Template by Diyor Khakimov

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 | Pratik Kumar | [pr2tik1/pr2tik1.github.io](https://github.com/pr2tik1/pr2tik1.github.io) | [pr2tik1.github.io](https://pr2tik1.github.io) |
 | Jayant Goel | [JayantGoel001/JayantGoel001.github.io](https://github.com/JayantGoel001/JayantGoel001.github.io) | [JayantGoel001.github.io](https://JayantGoel001.github.io/) |
 | Sagar Gupta | [Sagargupta16/portfolio-react](https://github.com/Sagargupta16/portfolio-react) | [sagargupta.online/portfolio-react](https://sagargupta.online/portfolio-react/) |
+| Diyor Khakimov | [diyoriko/portfolio-template](https://github.com/diyoriko/portfolio-template) | [diyor.design](https://diyor.design) |
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Adds **Portfolio Template by Diyor Khakimov** to the Templates table.

- **Repository:** [diyoriko/portfolio-template](https://github.com/diyoriko/portfolio-template)
- **Live demo:** [diyor.design](https://diyor.design)
- **Stack:** Vanilla HTML/CSS/JS (no frameworks)
- **Features:** Bilingual (EN/RU), dark mode, one-command setup script, case studies with image grids

Thank you for maintaining this awesome list!