### PR TITLE
Add v1–v4 portfolio versions to the templates list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@
 | Erwin Blog | [guilyx/hi.elejeune.me](https://github.com/guilyx/hi.elejeune.me) | [hi.elejeune.me](https://hi.elejeune.me) |
 | Unchained Labs | [unchained-labs/unchainlabs.xyz](https://github.com/unchained-labs/unchainlabs.xyz) | [unchainlabs.xyz](https://unchainlabs.xyz) |
 | Erwin Resume | [guilyx/resume](https://github.com/guilyx/resume) | [resume.elejeune.me](https://resume.elejeune.me) |
+| Erwin Portfolio v1 | [guilyx/v1](https://github.com/guilyx/v1) | [v1.elejeune.me](https://v1.elejeune.me) |
+| Erwin Portfolio v2 | [guilyx/v2](https://github.com/guilyx/v2) | [v2.elejeune.me](https://v2.elejeune.me) |
+| Erwin Portfolio v3 | [guilyx/v3](https://github.com/guilyx/v3) | [v3.elejeune.me](https://v3.elejeune.me) |
+| Erwin Portfolio v4 | [guilyx/v4](https://github.com/guilyx/v4) | [v4.elejeune.me](https://v4.elejeune.me) |
 | Gin Resume | [shoyogin/resume](https://github.com/shoyogin/resume) | [gin.unchainlabs.xyz](https://gin.unchainlabs.xyz) |
 | J Rosser | [jrosseruk/jrosseruk.github.io](https://github.com/jrosseruk/jrosseruk.github.io) | [jrosseruk.github.io](https://jrosseruk.github.io/) |
 | Ryan Fitzgerald | [RyanFitzgerald/devportfolio](https://github.com/RyanFitzgerald/devportfolio) | [ryanfitzgerald.github.io/devportfolio](https://ryanfitzgerald.github.io/devportfolio) |


### PR DESCRIPTION
## What are you bringing to the table ?


- [x] 🚀 Added Porfolio
- [ ] 🛠️ Added Tool
- [ ] 📰 Added Article
- [ ] ✨ Feature
- [ ] 🐛 Grammatical Error
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

Adds the four versions of my portfolio to the Templates table, placed next to the other Erwin entries. `resume.elejeune.me` (`guilyx/resume`) was already listed, so it is unchanged.

Repo↔domain mapping was checked against each repo's contents — `guilyx/v4` pins `site: "https://v4.elejeune.me"` in `astro.config.mjs`; v1–v3 are the corresponding earlier iterations (v2's README explicitly places itself between v1 and v3). The live URLs themselves could not be fetched from the environment this was written in (egress blocked), so those four links are worth an eyeball before merging.

## Add Link of GitHub Porfolio Template

| Name | Repository | Live Demo |
| --- | --- | --- |
| Erwin Portfolio v1 | [guilyx/v1](https://github.com/guilyx/v1) | [v1.elejeune.me](https://v1.elejeune.me) |
| Erwin Portfolio v2 | [guilyx/v2](https://github.com/guilyx/v2) | [v2.elejeune.me](https://v2.elejeune.me) |
| Erwin Portfolio v3 | [guilyx/v3](https://github.com/guilyx/v3) | [v3.elejeune.me](https://v3.elejeune.me) |
| Erwin Portfolio v4 | [guilyx/v4](https://github.com/guilyx/v4) | [v4.elejeune.me](https://v4.elejeune.me) |